### PR TITLE
Maximize master volume (#10)

### DIFF
--- a/src/base/sndio/AlsaUtils.hpp
+++ b/src/base/sndio/AlsaUtils.hpp
@@ -12,6 +12,9 @@ namespace signal_estimator {
 // open and setup ALSA PCM device
 snd_pcm_t* alsa_open(const char* device, snd_pcm_stream_t mode, Config& config);
 
+//set card volume to max
+void alsa_vol_set(const char *device, long volume);
+
 // close ALSA PCM device
 void alsa_close(snd_pcm_t* pcm);
 

--- a/src/base/sndio/AlsaWriter.cpp
+++ b/src/base/sndio/AlsaWriter.cpp
@@ -14,6 +14,7 @@ AlsaWriter::~AlsaWriter() {
 bool AlsaWriter::open(Config& config, const char* device) {
     se_log_info("opening alsa writer for device %s", device);
 
+    alsa_vol_set(device, 100);
     pcm_ = alsa_open(device, SND_PCM_STREAM_PLAYBACK, config);
     config_ = config;
 


### PR DESCRIPTION
When AlsaWriter::open() is run a call to a volume setting function is made. Storing the previous state of the mixer element volume is nontrivial because it can have 9 different channels shown [here](https://www.alsa-project.org/alsa-doc/alsa-lib/group___simple_mixer.html#gaf01a92f33cc46d0b3878d65afcc41b97). I see two options. One option is to assume that there is only mono or stereo. The other would be to store values in a container by getting the channels present. Do you think this is worth pursuing?