### PR TITLE
Use spdlog for logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,7 @@
 [submodule "3rdparty/concurrentqueue"]
 	path = 3rdparty/concurrentqueue
 	url = https://github.com/cameron314/concurrentqueue.git
+[submodule "3rdparty/spdlog"]
+	path = 3rdparty/spdlog
+	url = https://github.com/gabime/spdlog
+	branch = v1.x

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ target_include_directories(signal-estimator
 find_package(Threads)
 target_link_libraries(signal-estimator
   base_objects
+  m
   ${CMAKE_THREAD_LIBS_INIT}
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,8 @@ target_include_directories(signal-estimator
 find_package(Threads)
 target_link_libraries(signal-estimator
   base_objects
-  m
   ${CMAKE_THREAD_LIBS_INIT}
+  spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>
   )
 
 install(
@@ -157,6 +157,10 @@ if(BUILD_GUI)
   add_library(generated_objects OBJECT
     ${GENERATED_SOURCES}
     )
+
+  target_link_libraries(generated_objects
+	  PRIVATE spdlog::spdlog
+	  )
 
   add_dependencies(generated_objects
     ${ALL_DEPENDENCIES}
@@ -211,6 +215,7 @@ if(BUILD_GUI)
     ${QWT_LIBRARY}
     Qt5::Core
     Qt5::Widgets
+	spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>
     )
 
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,10 @@ target_include_directories(base_objects
   PRIVATE src/base
   )
 
+target_link_libraries(base_objects
+  PUBLIC spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>
+  )
+
 add_executable(signal-estimator
   src/cli/Main.cpp
   )
@@ -126,7 +130,6 @@ find_package(Threads)
 target_link_libraries(signal-estimator
   base_objects
   ${CMAKE_THREAD_LIBS_INIT}
-  spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>
   )
 
 install(
@@ -157,10 +160,6 @@ if(BUILD_GUI)
   add_library(generated_objects OBJECT
     ${GENERATED_SOURCES}
     )
-
-  target_link_libraries(generated_objects
-	  PRIVATE spdlog::spdlog
-	  )
 
   add_dependencies(generated_objects
     ${ALL_DEPENDENCIES}
@@ -215,7 +214,6 @@ if(BUILD_GUI)
     ${QWT_LIBRARY}
     Qt5::Core
     Qt5::Widgets
-	spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>
     )
 
   install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,6 @@ target_include_directories(base_objects
   PRIVATE src/base
   )
 
-#target_link_libraries(base_objects
-#  PUBLIC spdlog::spdlog
-#  )
-
 add_executable(signal-estimator
   src/cli/Main.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,9 +97,9 @@ target_include_directories(base_objects
   PRIVATE src/base
   )
 
-target_link_libraries(base_objects
-  PUBLIC spdlog::spdlog $<$<BOOL:${MINGW}>:ws2_32>
-  )
+#target_link_libraries(base_objects
+#  PUBLIC spdlog::spdlog
+#  )
 
 add_executable(signal-estimator
   src/cli/Main.cpp

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -125,14 +125,37 @@ include_directories(SYSTEM
 checkout_submodule(
   ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/spdlog
   )
-add_subdirectory(
-  ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/spdlog
-  )
+ExternalProject_Add(spdlog_lib
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/spdlog
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/3rdparty/spdlog-build
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}/3rdparty/spdlog-prefix
+  CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    -DCMAKE_C_COMPILER_TARGET=${CMAKE_C_COMPILER_TARGET}
+    -DCMAKE_CXX_COMPILER_TARGET=${CMAKE_CXX_COMPILER_TARGET}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_AR=${CMAKE_AR}
+    -DCMAKE_RANLIB=${CMAKE_RANLIB}
+    -DCMAKE_STRIP=${CMAKE_STRIP}
+  LOG_DOWNLOAD YES
+  LOG_CONFIGURE YES
+  LOG_BUILD YES
+  LOG_INSTALL YES
+)
+include_directories(SYSTEM
+  ${CMAKE_CURRENT_BINARY_DIR}/3rdparty/spdlog-prefix/include
+)
+link_libraries(
+  ${CMAKE_CURRENT_BINARY_DIR}/3rdparty/spdlog-prefix/lib/${LIBPREFIX}spdlog${LIBSUFFIX}
+)
 
 # serialize dependencies
 set(ALL_DEPENDENCIES
   alsa_lib
   kissfft_lib
+  spdlog_lib
   )
 
 list(REVERSE ALL_DEPENDENCIES)

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -122,6 +122,9 @@ include_directories(SYSTEM
 )
 
 # spdlog
+checkout_submodule(
+  ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/spdlog
+  )
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/3rdparty/spdlog/cmake")
 find_package(spdlog REQUIRED)
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -125,8 +125,9 @@ include_directories(SYSTEM
 checkout_submodule(
   ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/spdlog
   )
-list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/3rdparty/spdlog/cmake")
-find_package(spdlog REQUIRED)
+add_subdirectory(
+  ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/spdlog
+  )
 
 # serialize dependencies
 set(ALL_DEPENDENCIES

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -121,6 +121,10 @@ include_directories(SYSTEM
   ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/cxxopts/include
 )
 
+# spdlog
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/3rdparty/spdlog/cmake")
+find_package(spdlog REQUIRED)
+
 # serialize dependencies
 set(ALL_DEPENDENCIES
   alsa_lib

--- a/src/base/core/Log.hpp
+++ b/src/base/core/Log.hpp
@@ -5,6 +5,10 @@
 
 #include <cstdio>
 
-#define se_log_error(fmt, ...) fprintf(stderr, "error: " fmt "\n", ##__VA_ARGS__)
+#include "spdlog/spdlog.h"
+#include "spdlog/cfg/env.h"   // support for loading levels from the environment variable
+#include "spdlog/fmt/ostr.h"  // support for user defined types
 
-#define se_log_info(fmt, ...) fprintf(stderr, fmt "\n", ##__VA_ARGS__)
+#define se_log_error(fmt, ...) spdlog::error(fmt "\n", ##__VA_ARGS__)
+
+#define se_log_info(fmt, ...) spdlog::info(fmt "\n", ##__VA_ARGS__)

--- a/src/base/core/Log.hpp
+++ b/src/base/core/Log.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
 
-#define se_log_error(fmt, ...) spdlog::error(fmt "\n", ##__VA_ARGS__)
+#define se_log_error(fmt, ...) spdlog::error(fmt, ##__VA_ARGS__)
 
-#define se_log_info(fmt, ...) spdlog::info(fmt "\n", ##__VA_ARGS__)
+#define se_log_info(fmt, ...) spdlog::info(fmt, ##__VA_ARGS__)

--- a/src/base/core/Log.hpp
+++ b/src/base/core/Log.hpp
@@ -3,10 +3,6 @@
 
 #pragma once
 
-#include <cstdio>
-
-#include "spdlog/cfg/env.h" // support for loading levels from the environment variable
-#include "spdlog/fmt/ostr.h" // support for user defined types
 #include "spdlog/spdlog.h"
 
 #define se_log_error(fmt, ...) spdlog::error(fmt "\n", ##__VA_ARGS__)

--- a/src/base/core/Log.hpp
+++ b/src/base/core/Log.hpp
@@ -5,9 +5,9 @@
 
 #include <cstdio>
 
+#include "spdlog/cfg/env.h" // support for loading levels from the environment variable
+#include "spdlog/fmt/ostr.h" // support for user defined types
 #include "spdlog/spdlog.h"
-#include "spdlog/cfg/env.h"   // support for loading levels from the environment variable
-#include "spdlog/fmt/ostr.h"  // support for user defined types
 
 #define se_log_error(fmt, ...) spdlog::error(fmt "\n", ##__VA_ARGS__)
 

--- a/src/base/reports/CsvDumper.cpp
+++ b/src/base/reports/CsvDumper.cpp
@@ -38,7 +38,7 @@ bool CsvDumper::open(const char* filename) {
     }
 
     if (!fp_) {
-        se_log_error("can't open output file %s: %s", filename, strerror(errno));
+        se_log_error("can't open output file {}: {}", filename, strerror(errno));
         return false;
     }
 

--- a/src/base/sndio/AlsaReader.cpp
+++ b/src/base/sndio/AlsaReader.cpp
@@ -12,7 +12,7 @@ AlsaReader::~AlsaReader() {
 }
 
 bool AlsaReader::open(Config& config, const char* device) {
-    se_log_info("opening alsa reader for device %s", device);
+    se_log_info("opening alsa reader for device {}", device);
 
     pcm_ = alsa_open(device, SND_PCM_STREAM_CAPTURE, config);
     config_ = config;
@@ -41,7 +41,7 @@ bool AlsaReader::read(Frame& frame) {
     }
 
     if (err < 0) {
-        se_log_error("alsa reader: %s", snd_strerror((int)err));
+        se_log_error("alsa reader: {}", snd_strerror((int)err));
         return false;
     }
 

--- a/src/base/sndio/AlsaUtils.cpp
+++ b/src/base/sndio/AlsaUtils.cpp
@@ -72,7 +72,8 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     }
     if (rate != sample_rate) {
         se_log_error("can't set hw params: exact sample rate value is not supported:"
-                     " requested={:d} supported={:d}", sample_rate, rate);
+                     " requested={:d} supported={:d}",
+            sample_rate, rate);
         return false;
     }
 

--- a/src/base/sndio/AlsaUtils.cpp
+++ b/src/base/sndio/AlsaUtils.cpp
@@ -72,8 +72,7 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     }
     if (rate != sample_rate) {
         se_log_error("can't set hw params: exact sample rate value is not supported:"
-                     " requested={:d} supported={:d}",
-            (int)sample_rate, (int)rate);
+                     " requested={:d} supported={:d}", sample_rate, rate);
         return false;
     }
 
@@ -117,12 +116,12 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
         return false;
     }
 
-    se_log_info("suggested_latency: {:u} us", (unsigned)latency_us);
-    se_log_info("suggested_buffer_size: {:u} samples", (unsigned)suggested_buffer_size);
-    se_log_info("selected_buffer_time: {:u} us", (unsigned)buffer_time);
-    se_log_info("selected_buffer_size: {:u} samples", (unsigned)*buffer_size);
-    se_log_info("selected_period_time: {:u} us", (unsigned)period_time);
-    se_log_info("selected_period_size: {:u} samples", (unsigned)*period_size);
+    se_log_info("suggested_latency: {:u} us", latency_us);
+    se_log_info("suggested_buffer_size: {:u} samples", suggested_buffer_size);
+    se_log_info("selected_buffer_time: {:u} us", buffer_time);
+    se_log_info("selected_buffer_size: {:u} samples", *buffer_size);
+    se_log_info("selected_period_time: {:u} us", period_time);
+    se_log_info("selected_period_size: {:u} samples", *period_size);
 
     // send hw_params to ALSA
     if ((err = snd_pcm_hw_params(pcm, hw_params)) < 0) {

--- a/src/base/sndio/AlsaUtils.cpp
+++ b/src/base/sndio/AlsaUtils.cpp
@@ -30,13 +30,13 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     // initialize hw_params
     if ((err = snd_pcm_hw_params_any(pcm, hw_params)) < 0) {
         se_log_error(
-            "can't set hw params: snd_pcm_hw_params_any(): %s", snd_strerror(err));
+            "can't set hw params: snd_pcm_hw_params_any(): {}", snd_strerror(err));
         return false;
     }
 
     // disable software resampling
     if ((err = snd_pcm_hw_params_set_rate_resample(pcm, hw_params, 0)) < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_set_rate_resample: %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_set_rate_resample: {}",
             snd_strerror(err));
         return false;
     }
@@ -44,7 +44,7 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     // set number of channels
     if ((err = snd_pcm_hw_params_set_channels(pcm, hw_params, (unsigned int)n_channels))
         < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_set_channels(): %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_set_channels(): {}",
             snd_strerror(err));
         return false;
     }
@@ -52,27 +52,27 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     // set access
     if ((err = snd_pcm_hw_params_set_access(pcm, hw_params, access)) < 0) {
         se_log_error(
-            "can't set hw params: snd_pcm_hw_params_set_access(): %s", snd_strerror(err));
+            "can't set hw params: snd_pcm_hw_params_set_access(): {}", snd_strerror(err));
         return false;
     }
 
     // set format
     if ((err = snd_pcm_hw_params_set_format(pcm, hw_params, format)) < 0) {
         se_log_error(
-            "can't set hw params: snd_pcm_hw_params_set_format(): %s", snd_strerror(err));
+            "can't set hw params: snd_pcm_hw_params_set_format(): {}", snd_strerror(err));
         return false;
     }
 
     // set sample rate
     unsigned int rate = sample_rate;
     if ((err = snd_pcm_hw_params_set_rate_near(pcm, hw_params, &rate, nullptr)) < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_set_rate_near(): %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_set_rate_near(): {}",
             snd_strerror(err));
         return false;
     }
     if (rate != sample_rate) {
         se_log_error("can't set hw params: exact sample rate value is not supported:"
-                     " requested=%d supported=%d",
+                     " requested={:d} supported={:d}",
             (int)sample_rate, (int)rate);
         return false;
     }
@@ -87,7 +87,7 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     if ((err = snd_pcm_hw_params_set_period_size_near(
              pcm, hw_params, period_size, nullptr))
         < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_set_period_size_near(): %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_set_period_size_near(): {}",
             snd_strerror(err));
         return false;
     }
@@ -95,7 +95,7 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     // get period time
     unsigned int period_time = 0;
     if ((err = snd_pcm_hw_params_get_period_time(hw_params, &period_time, nullptr)) < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_get_period_time(): %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_get_period_time(): {}",
             snd_strerror(err));
         return false;
     }
@@ -103,7 +103,7 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     // set buffer size, i.e. number of samples in circular buffer
     *buffer_size = *period_size * n_periods;
     if ((err = snd_pcm_hw_params_set_buffer_size_near(pcm, hw_params, buffer_size)) < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_set_buffer_size_near(): %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_set_buffer_size_near(): {}",
             snd_strerror(err));
         return false;
     }
@@ -112,21 +112,21 @@ bool alsa_set_hw_params(snd_pcm_t* pcm, snd_pcm_uframes_t* period_size,
     // calculated from 'sample_rate' and 'buffer_size'
     unsigned int buffer_time = 0;
     if ((err = snd_pcm_hw_params_get_buffer_time(hw_params, &buffer_time, nullptr)) < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params_get_buffer_time(): %s",
+        se_log_error("can't set hw params: snd_pcm_hw_params_get_buffer_time(): {}",
             snd_strerror(err));
         return false;
     }
 
-    se_log_info("suggested_latency: %u us", (unsigned)latency_us);
-    se_log_info("suggested_buffer_size: %u samples", (unsigned)suggested_buffer_size);
-    se_log_info("selected_buffer_time: %u us", (unsigned)buffer_time);
-    se_log_info("selected_buffer_size: %u samples", (unsigned)*buffer_size);
-    se_log_info("selected_period_time: %u us", (unsigned)period_time);
-    se_log_info("selected_period_size: %u samples", (unsigned)*period_size);
+    se_log_info("suggested_latency: {:u} us", (unsigned)latency_us);
+    se_log_info("suggested_buffer_size: {:u} samples", (unsigned)suggested_buffer_size);
+    se_log_info("selected_buffer_time: {:u} us", (unsigned)buffer_time);
+    se_log_info("selected_buffer_size: {:u} samples", (unsigned)*buffer_size);
+    se_log_info("selected_period_time: {:u} us", (unsigned)period_time);
+    se_log_info("selected_period_size: {:u} samples", (unsigned)*period_size);
 
     // send hw_params to ALSA
     if ((err = snd_pcm_hw_params(pcm, hw_params)) < 0) {
-        se_log_error("can't set hw params: snd_pcm_hw_params(): %s", snd_strerror(err));
+        se_log_error("can't set hw params: snd_pcm_hw_params(): {}", snd_strerror(err));
         return false;
     }
 
@@ -143,7 +143,7 @@ bool alsa_set_sw_params(snd_pcm_t* pcm, snd_pcm_stream_t mode,
     // initialize sw_params
     if ((err = snd_pcm_sw_params_current(pcm, sw_params)) < 0) {
         se_log_error(
-            "can't set sw params: snd_pcm_sw_params_current(): %s", snd_strerror(err));
+            "can't set sw params: snd_pcm_sw_params_current(): {}", snd_strerror(err));
         return false;
     }
 
@@ -152,21 +152,21 @@ bool alsa_set_sw_params(snd_pcm_t* pcm, snd_pcm_stream_t mode,
         if ((err = snd_pcm_sw_params_set_start_threshold(pcm, sw_params, buffer_size))
             < 0) {
             se_log_error(
-                "can't set sw params: snd_pcm_sw_params_set_start_threshold(): %s",
+                "can't set sw params: snd_pcm_sw_params_set_start_threshold(): {}",
                 snd_strerror(err));
             return false;
         }
 
         // set minimum threshold, below which ALSA wont allow to perform write
         if ((err = snd_pcm_sw_params_set_avail_min(pcm, sw_params, period_size)) < 0) {
-            se_log_error("can't set sw params: snd_pcm_sw_params_set_avail_min(): %s",
+            se_log_error("can't set sw params: snd_pcm_sw_params_set_avail_min(): {}",
                 snd_strerror(err));
             return false;
         }
     } else {
         // set minimum threshold, below which ALSA wont allow to perform read
         if ((err = snd_pcm_sw_params_set_avail_min(pcm, sw_params, period_size)) < 0) {
-            se_log_error("can't set sw params: snd_pcm_sw_params_set_avail_min(): %s",
+            se_log_error("can't set sw params: snd_pcm_sw_params_set_avail_min(): {}",
                 snd_strerror(err));
             return false;
         }
@@ -174,7 +174,7 @@ bool alsa_set_sw_params(snd_pcm_t* pcm, snd_pcm_stream_t mode,
 
     // send sw_params to ALSA
     if ((err = snd_pcm_sw_params(pcm, sw_params)) < 0) {
-        se_log_error("can't set sw params: snd_pcm_sw_params(): %s", snd_strerror(err));
+        se_log_error("can't set sw params: snd_pcm_sw_params(): {}", snd_strerror(err));
         return false;
     }
 
@@ -188,7 +188,7 @@ snd_pcm_t* alsa_open(const char* device, snd_pcm_stream_t mode, Config& config) 
 
     int err = 0;
     if ((err = snd_pcm_open(&pcm, device, mode, 0)) < 0) {
-        se_log_error("can't open alsa device: snd_pcm_open(): %s", snd_strerror(err));
+        se_log_error("can't open alsa device: snd_pcm_open(): {}", snd_strerror(err));
         return nullptr;
     }
 
@@ -210,7 +210,7 @@ snd_pcm_t* alsa_open(const char* device, snd_pcm_stream_t mode, Config& config) 
 
 error:
     if ((err = snd_pcm_close(pcm)) < 0) {
-        se_log_error("can't close alsa device: snd_pcm_close(): %s", snd_strerror(err));
+        se_log_error("can't close alsa device: snd_pcm_close(): {}", snd_strerror(err));
     }
 
     return nullptr;
@@ -224,7 +224,7 @@ void alsa_close(snd_pcm_t* pcm) {
     int err = 0;
 
     if ((err = snd_pcm_close(pcm)) < 0) {
-        se_log_error("can't close alsa device: snd_pcm_close(): %s", snd_strerror(err));
+        se_log_error("can't close alsa device: snd_pcm_close(): {}", snd_strerror(err));
     }
 }
 

--- a/src/base/sndio/AlsaWriter.cpp
+++ b/src/base/sndio/AlsaWriter.cpp
@@ -12,7 +12,7 @@ AlsaWriter::~AlsaWriter() {
 }
 
 bool AlsaWriter::open(Config& config, const char* device) {
-    se_log_info("opening alsa writer for device %s", device);
+    se_log_info("opening alsa writer for device {}", device);
 
     pcm_ = alsa_open(device, SND_PCM_STREAM_PLAYBACK, config);
     config_ = config;
@@ -41,7 +41,7 @@ bool AlsaWriter::write(Frame& frame) {
     }
 
     if (err < 0) {
-        se_log_error("alsa writer: %s", snd_strerror((int)err));
+        se_log_error("alsa writer: {}", snd_strerror((int)err));
         return false;
     }
 

--- a/src/cli/Main.cpp
+++ b/src/cli/Main.cpp
@@ -22,6 +22,9 @@
 #include "sndio/IDeviceReader.hpp"
 #include "sndio/IDeviceWriter.hpp"
 
+#include "spdlog/async.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
 #include <iostream>
 #include <memory>
 #include <memory>
@@ -109,6 +112,10 @@ void input_loop( const Config* config, FramePool* frame_pool, IEstimator* estima
 } // namespace
 
 int main(int argc, char** argv) {
+
+	auto err_logger = spdlog::stderr_color_mt<spdlog::async_factory>("stderr");
+	spdlog::set_default_logger(err_logger);
+
     Config config;
 
     cxxopts::Options opts(
@@ -269,7 +276,7 @@ int main(int argc, char** argv) {
         config.glitch_detection_window = res["glitch-detection-window"].as<size_t>();
         config.glitch_detection_threshold = res["glitch-detection-threshold"].as<float>();
     } catch (std::exception& exc) {
-        se_log_error("%s", exc.what());
+        se_log_error("{}", exc.what());
         exit(1);
     }
 

--- a/src/cli/Main.cpp
+++ b/src/cli/Main.cpp
@@ -22,8 +22,9 @@
 #include "sndio/IDeviceReader.hpp"
 #include "sndio/IDeviceWriter.hpp"
 
-#include "spdlog/async.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
+#include <spdlog/spdlog.h>
+#include <spdlog/async.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 #include <iostream>
 #include <memory>

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -3,9 +3,9 @@
 
 #include "sndio/AlsaDeviceManager.hpp"
 
-#include "spdlog/async.h"
-#include "spdlog/sinks/stdout_color_sinks.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/spdlog.h>
+#include <spdlog/async.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
 
 #include "MainWindow.hpp"
 #include "NotFoundDialog.hpp"

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -3,9 +3,9 @@
 
 #include "sndio/AlsaDeviceManager.hpp"
 
-#include <spdlog/spdlog.h>
 #include <spdlog/async.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
 
 #include "MainWindow.hpp"
 #include "NotFoundDialog.hpp"

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -3,9 +3,9 @@
 
 #include "sndio/AlsaDeviceManager.hpp"
 
-#include "spdlog/spdlog.h"
 #include "spdlog/async.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
+#include "spdlog/spdlog.h"
 
 #include "MainWindow.hpp"
 #include "NotFoundDialog.hpp"
@@ -17,8 +17,8 @@ using namespace signal_estimator;
 
 int main(int argc, char* argv[]) {
 
-	auto err_logger = spdlog::stderr_color_mt<spdlog::async_factory>("stderr");
-	spdlog::set_default_logger(err_logger);
+    auto err_logger = spdlog::stderr_color_mt<spdlog::async_factory>("stderr");
+    spdlog::set_default_logger(err_logger);
 
     QApplication a(argc, argv);
 

--- a/src/gui/Main.cpp
+++ b/src/gui/Main.cpp
@@ -3,6 +3,10 @@
 
 #include "sndio/AlsaDeviceManager.hpp"
 
+#include "spdlog/spdlog.h"
+#include "spdlog/async.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
 #include "MainWindow.hpp"
 #include "NotFoundDialog.hpp"
 #include "SignalEstimator.hpp"
@@ -12,6 +16,10 @@
 using namespace signal_estimator;
 
 int main(int argc, char* argv[]) {
+
+	auto err_logger = spdlog::stderr_color_mt<spdlog::async_factory>("stderr");
+	spdlog::set_default_logger(err_logger);
+
     QApplication a(argc, argv);
 
     if (SignalEstimator::find().isEmpty()) {


### PR DESCRIPTION
Resolves #38 

spdlog is linked against base_objects in CMakeLists.txt, since it is required by both CLI and GUI. Asynchronous logging has been used.