### PR TITLE
White plot background for light color schemes

### DIFF
--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -26,6 +26,10 @@ MainWindow::MainWindow(IDeviceManager& device_manager, QWidget* parent)
     connect(signal_estimator_, &SignalEstimator::can_read, this,
         &MainWindow::read_graph_data);
 
+    ui->OutputSig->setCanvasBackground(QApplication::palette().base().color());
+    ui->ResultPlot1->setCanvasBackground(QApplication::palette().base().color());
+    ui->ResultPlot2->setCanvasBackground(QApplication::palette().base().color());
+
     outputCurve_->setPen(QColor(0x1F77B4));
     outputCurve_->attach(ui->OutputSig);
 


### PR DESCRIPTION
Attempt to solve #70
White plot background is not guaranteed. It should be the same color as text input fields, which usually is white for light themes. Feel free to discard PR, if this does not satisfy criteria.